### PR TITLE
windows support

### DIFF
--- a/src/leiningen/native_image.clj
+++ b/src/leiningen/native_image.clj
@@ -9,13 +9,17 @@
             [leiningen.core.project :as project])
   (:import (java.io File)))
 
+(def windows? (cs/starts-with? (System/getProperty "os.name") "Windows"))
+
+(defonce filename (if windows? "native-image.cmd" "native-image"))
+
 (defn- absolute-path [f & fs]
   (.getAbsolutePath ^File (apply io/file f fs)))
 
 (defn- native-image-path [bin]
   (cond
     (nil? bin)
-    "native-image" ;; assumed to be on PATH
+    filename ;; assumed to be on PATH
 
     (keyword? bin)
     (if (= "env" (namespace bin))
@@ -23,17 +27,18 @@
       (native-image-path (name bin)))
 
     (string? bin)
-    (let [paths [(io/file bin "bin/native-image")
-                 (io/file bin "native-image")]]
-      (debug "Looking for native-image at following paths:" (cs/join "; " (map str paths)))
-      (if (cs/ends-with? bin "/native-image")
+    (let [paths [(io/file bin (str "bin/" filename))
+                 (io/file bin filename)]]
+      (debug ">>>Looking for native-image at following paths:" (cs/join "; " (map str paths)))
+      (if (cs/ends-with? bin filename)
         bin
         (or (some->> paths
                      (filter #(.exists %))
                      (first)
                      (absolute-path))
             (do (warn "Couldn't find native-image command. You may need to install it with `gu install native-image`.")
-                (exit -1 "Couldn't find native-image command")))))
+                (exit -1 "Couldn't find native-image command")
+                ))))
 
     :else bin))
 


### PR DESCRIPTION
Have added Windows support for 'native-image.cmd' in a similar way to how you've done it in clj.native-image