### PR TITLE
Add :native-image map as profile

### DIFF
--- a/src/leiningen/native_image.clj
+++ b/src/leiningen/native_image.clj
@@ -61,8 +61,9 @@
         project    (if profile
                      (project/merge-profiles project [profile])
                      project)
-        _          (compile/compile project :all)
         config     (:native-image project)
+        project    (project/merge-profiles project [config])
+        _          (compile/compile project :all)
         entrypoint (-> (name (:main project))
                        (cs/replace #"\-" "_"))
         dest-path  (absolute-path


### PR DESCRIPTION
Overrides like :jvm-opts inside :native-image, either at top level or as
a nested value inside a profile, currently don't have an effect, because
compilation is done with project data that never looked inside
:native-image yet.

Using the map associated with the project's :native-image value at that
point and treating it as another profile fixes this.

-------
I noticed this in https://github.com/weavejester/cljfmt, where `:jvm-opts` are overridden inside `:native-image` in the `:uberjar` profile, but they don't have an effect. Moving the `:jvm-opts` into the profile or even the top level configuration works and there's a noticeable speed improvement.

It looks to me like all the other options work because `config` (the value of `:native-image`) is then used with GraalVM only, but `:jvm-opts` and other non-graal-related keys don't have an effect there and are never visible to the compiler step, because they are nested away.